### PR TITLE
Fix bug in implementation for updating a post

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ## Changelog
 
+## 22 February 2025
+- Correct variable names in `PostController.java`
+- Fix bug in `PostService.java` for updating a post; missing utilisation of `postRepository` and calling `save` to update corresponding entity in database
+- Add date processing for `modifiedAt` when a post is being updated
+
 ### 19 February 2025
 - Update return types of methods in `PostController.java` to control response status codes
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Changelog
 
+### 19 February 2025
+- Update return types of methods in `PostController.java` to control response status codes
+
 ### 18 February 2025
 - Add support for `PATCH` HTTP requests
 

--- a/src/main/java/mariellelopez/playground/posts/CreatePostDTO.java
+++ b/src/main/java/mariellelopez/playground/posts/CreatePostDTO.java
@@ -4,16 +4,16 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class CreatePostDTO {
     @NotBlank
     private String title;
     @NotNull
-    private Date createdAt;
+    private LocalDateTime createdAt;
     @NotNull
-    private Date modifiedAt;
+    private LocalDateTime modifiedAt;
     @NotBlank
     private String author;
     @NotBlank
@@ -29,11 +29,11 @@ public class CreatePostDTO {
         return this.title;
     };
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return this.createdAt;
     };
 
-    public Date getModifiedAt() {
+    public LocalDateTime getModifiedAt() {
         return this.modifiedAt;
     };
 

--- a/src/main/java/mariellelopez/playground/posts/Post.java
+++ b/src/main/java/mariellelopez/playground/posts/Post.java
@@ -2,7 +2,7 @@ package mariellelopez.playground.posts;
 
 import jakarta.persistence.*;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -14,9 +14,9 @@ public class Post {
     @Column
     private String title;
     @Column
-    private Date createdAt;
+    private LocalDateTime createdAt;
     @Column
-    private Date modifiedAt;
+    private LocalDateTime modifiedAt;
     @Column
     private String author;
     @Column
@@ -44,19 +44,19 @@ public class Post {
         this.title = title;
     };
 
-    public Date getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return this.createdAt;
     };
 
-    public void setCreatedAt(Date createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     };
 
-    public Date getModifiedAt() {
+    public LocalDateTime getModifiedAt() {
         return this.modifiedAt;
     };
 
-    public void setModifiedAt(Date modifiedAt) {
+    public void setModifiedAt(LocalDateTime modifiedAt) {
         this.modifiedAt = modifiedAt;
     };
 
@@ -76,7 +76,7 @@ public class Post {
         this.introduction = introduction;
     };
 
-    public String body() {
+    public String getBody() {
         return this.body;
     };
 

--- a/src/main/java/mariellelopez/playground/posts/PostController.java
+++ b/src/main/java/mariellelopez/playground/posts/PostController.java
@@ -1,7 +1,6 @@
 package mariellelopez.playground.posts;
 
 import jakarta.validation.Valid;
-import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,9 +41,9 @@ public class PostController {
     @PatchMapping("/{id}")
     public ResponseEntity<Post> updatePostById(@PathVariable Long id, @Valid @RequestBody UpdatePostDTO data) {
         Optional<Post> maybePost = this.postService.updatePostById(id, data);
-        Post createdPost = maybePost.orElseThrow(() -> new RuntimeException("Post not found"));
+        Post updatedPost = maybePost.orElseThrow(() -> new RuntimeException("Post not found"));
 
-        return new ResponseEntity<>(createdPost, HttpStatus.OK);
+        return new ResponseEntity<>(updatedPost, HttpStatus.OK);
     };
 
     @DeleteMapping("/{id}")

--- a/src/main/java/mariellelopez/playground/posts/PostService.java
+++ b/src/main/java/mariellelopez/playground/posts/PostService.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,6 +53,17 @@ public class PostService {
             updatedPost.setAuthor(data.getAuthor());
         };
 
+        if (data.getModifiedAt() != null) {
+            System.out.println("Original: " + data.getModifiedAt());
+
+            String formattedDate = data.getModifiedAt().replace("Z", "");
+
+            System.out.println("Processed: " + formattedDate);
+
+            LocalDateTime processedDate = LocalDateTime.parse(formattedDate);
+            updatedPost.setModifiedAt(processedDate);
+        }
+
         if (data.getIntroduction() != null) {
             updatedPost.setIntroduction(data.getIntroduction());
         };
@@ -69,8 +80,7 @@ public class PostService {
             updatedPost.setTags(data.getTags());
         };
 
-        updatedPost.setModifiedAt(new Date());
-
+        this.postRepository.save(updatedPost);
         return Optional.of(updatedPost);
     };
 

--- a/src/main/java/mariellelopez/playground/posts/UpdatePostDTO.java
+++ b/src/main/java/mariellelopez/playground/posts/UpdatePostDTO.java
@@ -10,6 +10,8 @@ public class UpdatePostDTO {
     private String title;
     @Pattern(regexp = "^(?=\\S).*$", message = "Author cannot be empty")
     private String author;
+    @Pattern(regexp = "^(?=\\S).*$", message = "Modified date cannot be empty")
+    private String modifiedAt;
     @Pattern(regexp = "^(?=\\S).*$", message = "Introduction cannot be empty")
     private String introduction;
     @Pattern(regexp = "^(?=\\S).*$", message = "Body cannot be empty")
@@ -21,6 +23,10 @@ public class UpdatePostDTO {
     public String getTitle() {
         return this.title;
     };
+
+    public String getModifiedAt() {
+        return this.modifiedAt;
+    }
 
     public String getAuthor() {
         return this.author;


### PR DESCRIPTION
# Describe your changes
- Add `modifiedAt` date to updatable content of a post
- Add missing use of `postRepository` in `updatePostById`
- Replace deprecated `Date` with `LocalDateTime`
- Process `modifiedAt` date in `PATCH` requests